### PR TITLE
Use blkid to get PARTLABEL because lsblk depends on udev which isn't …

### DIFF
--- a/pkg/ceph/osd/daemon_test.go
+++ b/pkg/ceph/osd/daemon_test.go
@@ -95,9 +95,14 @@ func TestAvailableDevices(t *testing.T) {
 			if strings.Index(name, "sdb") != -1 {
 				// /dev/sdb has a partition
 				return `NAME="sdb" SIZE="65" TYPE="disk" PKNAME="" PARTLABEL=""
-NAME="sdb1" SIZE="30" TYPE="part" PKNAME="sdb" PARTLABEL="MY-PART"`, nil
+NAME="sdb1" SIZE="30" TYPE="part" PKNAME="sdb"`, nil
 			}
 			return "", nil
+		} else if command == "blkid" {
+			if strings.Index(name, "sdb1") != -1 {
+				// partition sdb1 has a label MY-PART
+				return "MY-PART", nil
+			}
 		} else if command == "df" {
 			if strings.Index(name, "sdc") != -1 {
 				// /dev/sdc has a file system
@@ -106,7 +111,7 @@ NAME="sdb1" SIZE="30" TYPE="part" PKNAME="sdb" PARTLABEL="MY-PART"`, nil
 			return "", nil
 		}
 
-		return "", fmt.Errorf("unknown command %s", command)
+		return "", fmt.Errorf("unknown command %s %+v", command, args)
 	}
 
 	context := &clusterd.Context{ProcMan: proc.New(executor), Executor: executor}

--- a/pkg/ceph/osd/device_test.go
+++ b/pkg/ceph/osd/device_test.go
@@ -123,13 +123,22 @@ func TestOverwriteRookOwnedPartitions(t *testing.T) {
 		logger.Infof("OUTPUT %d for %s. %s %+v", outputExecCount, name, command, args)
 		var output string
 		switch outputExecCount {
-		case 0, 1: // we'll call this twice, once explicitly below to verify rook owns the partitions and a 2nd time within formatDevice
+		case 0, 4: // we'll call this twice, once explicitly below to verify rook owns the partitions and a 2nd time within formatDevice
 			assert.Equal(t, command, "lsblk")
 			output = `NAME="sda" SIZE="65" TYPE="disk" PKNAME="" PARTLABEL=""
-NAME="sda1" SIZE="30" TYPE="part" PKNAME="sda" PARTLABEL="ROOK-OSD0-WAL"
-NAME="sda2" SIZE="10" TYPE="part" PKNAME="sda" PARTLABEL="ROOK-OSD0-DB"
-NAME="sda3" SIZE="20" TYPE="part" PKNAME="sda" PARTLABEL="ROOK-OSD0-BLOCK"`
-		case 2:
+NAME="sda1" SIZE="30" TYPE="part" PKNAME="sda"
+NAME="sda2" SIZE="10" TYPE="part" PKNAME="sda"
+NAME="sda3" SIZE="20" TYPE="part" PKNAME="sda"`
+		case 1, 5:
+			assert.Equal(t, "blkid /dev/sda1", name)
+			output = "ROOK-OSD0-WAL"
+		case 2, 6:
+			assert.Equal(t, "blkid /dev/sda2", name)
+			output = "ROOK-OSD0-DB"
+		case 3, 7:
+			assert.Equal(t, "blkid /dev/sda3", name)
+			output = "ROOK-OSD0-BLOCK"
+		case 8:
 			assert.Equal(t, command, "df")
 			output = ""
 		}
@@ -163,7 +172,7 @@ NAME="sda3" SIZE="20" TYPE="part" PKNAME="sda" PARTLABEL="ROOK-OSD0-BLOCK"`
 	err = formatDevice(context, config, false, storeConfig)
 	assert.Nil(t, err)
 	assert.Equal(t, 3, execCount)
-	assert.Equal(t, 3, outputExecCount)
+	assert.Equal(t, 9, outputExecCount)
 }
 
 func TestPartitionBluestoreMetadata(t *testing.T) {

--- a/pkg/util/sys/device_test.go
+++ b/pkg/util/sys/device_test.go
@@ -129,23 +129,43 @@ func TestGetPartitions(t *testing.T) {
 			run++
 			switch {
 			case run == 1:
-				return `NAME="sdc" SIZE="100000" TYPE="disk" PKNAME="" PARTLABEL=""`, nil
+				return `NAME="sdc" SIZE="100000" TYPE="disk" PKNAME=""`, nil
 			case run == 2:
-				return `NAME="sdb" SIZE="65" TYPE="disk" PKNAME="" PARTLABEL=""
-NAME="sdb2" SIZE="10" TYPE="part" PKNAME="sdb" PARTLABEL="ROOK-OSD0-DB"
-NAME="sdb3" SIZE="20" TYPE="part" PKNAME="sdb" PARTLABEL="ROOK-OSD0-BLOCK"
-NAME="sdb1" SIZE="30" TYPE="part" PKNAME="sdb" PARTLABEL="ROOK-OSD0-WAL"`, nil
+				return `NAME="sdb" SIZE="65" TYPE="disk" PKNAME=""
+NAME="sdb2" SIZE="10" TYPE="part" PKNAME="sdb"
+NAME="sdb3" SIZE="20" TYPE="part" PKNAME="sdb"
+NAME="sdb1" SIZE="30" TYPE="part" PKNAME="sdb"`, nil
 			case run == 3:
-				return `NAME="sda" SIZE="19818086400" TYPE="disk" PKNAME="" PARTLABEL=""
-NAME="sda4" SIZE="1073741824" TYPE="part" PKNAME="sda" PARTLABEL="USR-B"
-NAME="sda2" SIZE="2097152" TYPE="part" PKNAME="sda" PARTLABEL="BIOS-BOOT"
-NAME="sda9" SIZE="17328766976" TYPE="part" PKNAME="sda" PARTLABEL="ROOT"
-NAME="sda7" SIZE="67108864" TYPE="part" PKNAME="sda" PARTLABEL="OEM-CONFIG"
-NAME="sda3" SIZE="1073741824" TYPE="part" PKNAME="sda" PARTLABEL="USR-A"
-NAME="usr" SIZE="1065345024" TYPE="crypt" PKNAME="sda3" PARTLABEL=""
-NAME="sda1" SIZE="134217728" TYPE="part" PKNAME="sda" PARTLABEL="EFI-SYSTEM"
-NAME="sda6" SIZE="134217728" TYPE="part" PKNAME="sda" PARTLABEL="OEM"`, nil
+				return "ROOK-OSD0-DB", nil
 			case run == 4:
+				return "ROOK-OSD0-BLOCK", nil
+			case run == 5:
+				return "ROOK-OSD0-WAL", nil
+			case run == 6:
+				return `NAME="sda" SIZE="19818086400" TYPE="disk" PKNAME=""
+NAME="sda4" SIZE="1073741824" TYPE="part" PKNAME="sda"
+NAME="sda2" SIZE="2097152" TYPE="part" PKNAME="sda"
+NAME="sda9" SIZE="17328766976" TYPE="part" PKNAME="sda"
+NAME="sda7" SIZE="67108864" TYPE="part" PKNAME="sda"
+NAME="sda3" SIZE="1073741824" TYPE="part" PKNAME="sda"
+NAME="usr" SIZE="1065345024" TYPE="crypt" PKNAME="sda3"
+NAME="sda1" SIZE="134217728" TYPE="part" PKNAME="sda"
+NAME="sda6" SIZE="134217728" TYPE="part" PKNAME="sda"`, nil
+			case run == 7:
+				return "USR-B", nil
+			case run == 8:
+				return "BIOS-BOOT", nil
+			case run == 9:
+				return "ROOT", nil
+			case run == 10:
+				return "OEM-CONFIG", nil
+			case run == 11:
+				return "USR-A", nil
+			case run == 12:
+				return "EFI-SYSTEM", nil
+			case run == 13:
+				return "OEM", nil
+			case run == 14:
 				return "", nil
 			}
 			return "", nil


### PR DESCRIPTION
…available in containers